### PR TITLE
fix: allow posting even during preview

### DIFF
--- a/app/islands/ContentForm.tsx
+++ b/app/islands/ContentForm.tsx
@@ -32,12 +32,15 @@ export default function ContentForm({ initialValue = '' }: Props) {
         </label>
       </div>
       {preview ? (
-        <div
-          id="contents"
-          dangerouslySetInnerHTML={{
-            __html: parseMarkdown(value)
-          }}
-        />
+        <>
+          <div
+            id="contents"
+            dangerouslySetInnerHTML={{
+              __html: parseMarkdown(value)
+            }}
+          />
+          <input type="hidden" name="content" value={value} />
+        </>
       ) : (
         <textarea
           id="content"


### PR DESCRIPTION
Hello. Thank you for the wonderful sample app.
I found a little bug when I was trying it out, so I fixed it.
The textarea value is empty when trying to post in Preview mode in ContentForm.

## Before

https://github.com/yusukebe/sonik-blog/assets/80559385/cc0f0b6c-4df4-4f21-b308-966ef62a3731

## After

https://github.com/yusukebe/sonik-blog/assets/80559385/0e8ba24d-cbd1-4bef-88bc-770169b2b1f0



